### PR TITLE
Add type annotations to tests

### DIFF
--- a/src/ehsi.rs
+++ b/src/ehsi.rs
@@ -487,7 +487,7 @@ mod test {
         let test_data = test::build_hs_test_data();
 
         for item in test_data.iter() {
-            let hsi = eHsi::from_color(&item.rgb);
+            let hsi = eHsi::<f32>::from_color(&item.rgb);
             if hsi.is_same_as_hsi() {
                 println!("{}; {}; {}", hsi, item.hsi, item.rgb);
                 assert_relative_eq!(hsi.hue(), item.hsi.hue(), epsilon = 1e-1);

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -380,12 +380,18 @@ mod test {
 
     #[test]
     fn test_get_hue() {
-        assert_ulps_eq!(Hsv::new(Deg(120.0), 0.25, 0.75).get_hue(), Deg(120.0));
         assert_ulps_eq!(
-            Hsv::new(Deg(180.0_f32), 0.35, 0.55).get_hue(),
+            Hsv::new(Deg(120.0), 0.25, 0.75).get_hue::<Deg<f32>>(),
+            Deg(120.0)
+        );
+        assert_ulps_eq!(
+            Hsv::new(Deg(180.0_f32), 0.35, 0.55).get_hue::<Rad<f32>>(),
             Rad(consts::PI)
         );
-        assert_ulps_eq!(Hsv::new(Turns(0.0), 0.00, 0.00).get_hue(), Rad(0.0));
+        assert_ulps_eq!(
+            Hsv::new(Turns(0.0), 0.00, 0.00).get_hue::<Rad<f32>>(),
+            Rad(0.0)
+        );
     }
 
     #[test]

--- a/src/lchuv.rs
+++ b/src/lchuv.rs
@@ -383,8 +383,8 @@ mod test {
     #[test]
     fn test_get_hue() {
         let c1 = Lchuv::<_, D65, _>::new(22.0, 98.0, Deg(120.0));
-        assert_relative_eq!(c1.get_hue(), Deg(120.0));
-        assert_relative_eq!(c1.get_hue(), Turns(1.0 / 3.0));
+        assert_relative_eq!(c1.get_hue::<Deg<f32>>(), Deg(120.0));
+        assert_relative_eq!(c1.get_hue::<Turns<f32>>(), Turns(1.0 / 3.0));
     }
 
     #[test]

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -483,12 +483,12 @@ mod test {
     #[test]
     fn test_hue() {
         let c1 = Rgb::new(1.0_f32, 0.0, 0.0);
-        assert_ulps_eq!(c1.get_hue(), Deg(0.0));
-        assert_ulps_eq!(Rgb::new(0.0, 1.0_f32, 0.0).get_hue(), Deg(120.0));
-        assert_ulps_eq!(Rgb::new(0.0, 0.0_f32, 1.0).get_hue(), Deg(240.0));
-        assert_relative_eq!(Rgb::new(0.5, 0.5, 0.0).get_hue(), Deg(60.0), epsilon = 1e-6);
+        assert_ulps_eq!(c1.get_hue::<Deg<f32>>(), Deg(0.0));
+        assert_ulps_eq!(Rgb::new(0.0, 1.0_f32, 0.0).get_hue::<Deg<f32>>(), Deg(120.0));
+        assert_ulps_eq!(Rgb::new(0.0, 0.0_f32, 1.0).get_hue::<Deg<f32>>(), Deg(240.0));
+        assert_relative_eq!(Rgb::new(0.5, 0.5, 0.0).get_hue::<Deg<f32>>(), Deg(60.0), epsilon = 1e-6);
         assert_relative_eq!(
-            Rgb::new(0.5, 0.0, 0.5).get_hue(),
+            Rgb::new(0.5, 0.0, 0.5).get_hue::<Deg<f32>>(),
             Deg(300.0),
             epsilon = 1e-6
         );


### PR DESCRIPTION
A very small PR that fixes the tests: they now require a type annotation. Other than the annotation nothing else has changed.